### PR TITLE
Use charm-base:base-version path format + add groovy/hirsute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_IMAGE=sh -c '. "./make_functions.sh"; build_image "$$@"' build_image
 
 default: build-ubuntu
 
-build-ubuntu: ubuntu\:20.04 ubuntu\:18.04
+build-ubuntu: ubuntu\:20.04 ubuntu\:18.04 ubuntu\:20.10 ubuntu\:21.04
 
 ubuntu\:% :
 	$(BUILD_IMAGE) $(shell echo  $@ | cut -f 2 -d ':')

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -17,10 +17,12 @@ _base_image() {
 
 _image_path() {
     BASE_TAG=$1
-    echo "${DOCKER_USERNAME}/${BASE_IMAGE}:${BASE_TAG}"
+    echo "${DOCKER_USERNAME}/charm-base:${BASE_IMAGE}-${BASE_TAG}"
 }
 
 build_image() {
     BASE_TAG=$1
-    "${DOCKER_BIN}" build --build-arg BASE_IMAGE=$(_base_image $BASE_TAG) -t "$(_image_path $BASE_TAG)" -f "Dockerfile-${BASE_IMAGE}" .
+    BASE_IMAGE_PATH=$(_base_image $BASE_TAG)
+    "${DOCKER_BIN}" pull ${BASE_IMAGE_PATH}
+    "${DOCKER_BIN}" build --build-arg BASE_IMAGE=${BASE_IMAGE_PATH} -t "$(_image_path $BASE_TAG)" -f "Dockerfile-${BASE_IMAGE}" .
 }


### PR DESCRIPTION
- Rewrite image name and tag to be under charm-base name. e.g. jujusolutions/charm-base:ubuntu-20.04
- Added 20.10(groovy) and 21.04(hirsute) to makefile