### PR TITLE
[JUJU-630] Swaps over to using matrix for build.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,14 +2,33 @@ name: build
 on:
   pull_request: {}
 jobs:
-  build-docker-images:
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make jq
+          wget https://github.com/mikefarah/yq/releases/download/v4.20.1/yq_linux_amd64 -O /usr/bin/yq &&\
+          chmod +x /usr/bin/yq
+      - id: set-matrix
+        run: |
+          echo "::set-output name=matrix::{\"image\": $(make images-json)}"
+
+  build-docker-image:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v1
 
       - name: Checkout
@@ -20,8 +39,8 @@ jobs:
           sudo apt update
           sudo apt install -y make
           wget https://github.com/mikefarah/yq/releases/download/v4.20.1/yq_linux_amd64 -O /usr/bin/yq &&\
-              chmod +x /usr/bin/yq
+          chmod +x /usr/bin/yq
 
-      - name: Make build Ubuntu images
+      - name: Make build image ${{ matrix.image }}
         run: |
-          make build
+          IMAGES=${{ matrix.image }} make build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,8 +3,28 @@ on:
   push:
     branches: master
 jobs:
-  build-docker-images:
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make jq
+          wget https://github.com/mikefarah/yq/releases/download/v4.20.1/yq_linux_amd64 -O /usr/bin/yq &&\
+          chmod +x /usr/bin/yq
+      - id: set-matrix
+        run: |
+          echo "::set-output name=matrix::{\"image\": $(make images-json)}"
+
+  push-docker-image:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -29,6 +49,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Make build Ubuntu images
+      - name: Make push image ${{ matrix.image }}
         run: |
-          make push
+          IMAGES=${{ matrix.image }} make push

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Licensed under the AGPLv3, see LICENCE file for details.
 
 BUILD_IMAGE=bash -c '. "./make_functions.sh"; build_image "$$@"' build_image
-IMAGES=$(shell cat images.yaml | yq -o=t '.images | keys')
+IMAGES?=$(shell yq -o=t '.images | keys' < images.yaml)
 
 default: build
 
@@ -11,6 +11,9 @@ build: $(IMAGES)
 
 check:
 	shellcheck ./*.sh
+
+images-json:
+	@yq -o=j '.images | keys' < images.yaml | jq -c
 
 push: OUTPUT_TYPE = "type=image,push=true"
 push: $(IMAGES)

--- a/images.yaml
+++ b/images.yaml
@@ -1,35 +1,61 @@
 images:
-  ubuntu:
+  ubuntu-21-10:
     dockerfile: Dockerfile-ubuntu
     context: ubuntu-context
     registry_paths:
       - jujusolutions/charm-base
-    bases:
-      ubuntu:21.10:
-        name: impish
-        platforms:
-          - linux/arm64
-          - linux/amd64
-          - linux/ppc64le
-          - linux/s390x
-      ubuntu:21.04:
-        name: hirsute
-        platforms:
-          - linux/arm64
-          - linux/amd64
-          - linux/ppc64le
-          - linux/s390x
-      ubuntu:20.04:
-        name: focal
-        platforms:
-          - linux/arm64
-          - linux/amd64
-          - linux/ppc64le
-          - linux/s390x
-      ubuntu:18.04:
-        name: bionic
-        platforms:
-          - linux/arm64
-          - linux/amd64
-          - linux/ppc64le
-          - linux/s390x
+    tags:
+      - ubuntu-21.10
+      - latest
+    platforms:
+      - linux/arm64
+      - linux/amd64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      - "BASE_IMAGE=ubuntu:21.10"
+
+  ubuntu-21-04:
+    dockerfile: Dockerfile-ubuntu
+    context: ubuntu-context
+    registry_paths:
+      - jujusolutions/charm-base
+    tags:
+      - ubuntu-21.04
+    platforms:
+      - linux/arm64
+      - linux/amd64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      - "BASE_IMAGE=ubuntu:21.04"
+
+  ubuntu-20-04:
+    dockerfile: Dockerfile-ubuntu
+    context: ubuntu-context
+    registry_paths:
+      - jujusolutions/charm-base
+    tags:
+      - ubuntu-20.04
+    platforms:
+      - linux/arm64
+      - linux/amd64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      - "BASE_IMAGE=ubuntu:20.04"
+
+  ubuntu-18-04:
+    dockerfile: Dockerfile-ubuntu
+    context: ubuntu-context
+    registry_paths:
+      - jujusolutions/charm-base
+    tags:
+      - ubuntu-18.04
+    platforms:
+      - linux/arm64
+      - linux/amd64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      - "BASE_IMAGE=ubuntu:18.04"


### PR DESCRIPTION
As we have several docker images to build GH actions now work on a mtrix
where each image is seperated into it's own step in Github actions
making fault finding easier.