### PR TITLE
[JUJU-2837] Update Docker base images to new repo.

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -4,9 +4,9 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-# Python dependencies.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get update
+
+RUN apt-get install -y --no-install-recommends \
     python3-yaml \
     python3-pip \
     python3-distutils \
@@ -15,7 +15,7 @@ RUN apt-get update \
     # below apt dependencies are required by controller pod.
     iproute2 \
     curl \
-    && pip3 install --upgrade pip setuptools \
+	&& pip3 install --upgrade pip setuptools \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /root/.cache
 

--- a/images.yaml
+++ b/images.yaml
@@ -13,9 +13,8 @@ images:
       - linux/amd64
       - linux/ppc64le
       - linux/s390x
-      - linux/riscv64
     build_args:
-      - "BASE_IMAGE=ubuntu:22.04"
+      - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:22.04"
     juju_test_channel: 3.0/stable
     microk8s_test_channel: 1.25-strict/stable
     series: jammy
@@ -33,9 +32,8 @@ images:
       - linux/amd64
       - linux/ppc64le
       - linux/s390x
-      - linux/riscv64
     build_args:
-      - "BASE_IMAGE=ubuntu:20.04"
+      - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:20.04"
     juju_test_channel: 2.9/stable
     microk8s_test_channel: 1.25/stable
     series: focal
@@ -54,7 +52,7 @@ images:
       - linux/ppc64le
       - linux/s390x
     build_args:
-      - "BASE_IMAGE=ubuntu:18.04"
+      - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:18.04"
     juju_test_channel: 2.9/stable
     microk8s_test_channel: 1.25/stable
     series: bionic


### PR DESCRIPTION
- Updates base image repo's to use Ubuntu from a more frequently updated Canonical source.

- Seperates RUN commands in the Dockerfile to fix intermittent issues with apt.

- Removes RISKv architectures as they are not available and stopping building of images.