### PR TITLE
ghcr.io repository + juju (170:170) user and group

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,17 +104,24 @@ jobs:
           EOF
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ECR Public 
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
           username: ${{ secrets.RELEASE_ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.RELEASE_ECR_SECRET_ACCESS_KEY }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images
         if: ${{ success() && github.ref == 'refs/heads/master' }}

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -4,9 +4,13 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-RUN apt-get update
+# Add the juju user for rootless agents.
+# 170 uid/gid is sourced from juju/juju
+RUN groupadd --gid 170 juju
+RUN useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
     python3-yaml \
     python3-pip \
     python3-distutils \

--- a/images.yaml
+++ b/images.yaml
@@ -6,6 +6,7 @@ images:
     registry_paths:
       - docker.io/jujusolutions/charm-base
       - public.ecr.aws/juju/charm-base
+      - ghcr.io/juju/charm-base
     tags:
       - ubuntu-22.04
       - latest
@@ -27,6 +28,7 @@ images:
     registry_paths:
       - docker.io/jujusolutions/charm-base
       - public.ecr.aws/juju/charm-base
+      - ghcr.io/juju/charm-base
     tags:
       - ubuntu-20.04
     platforms:
@@ -47,6 +49,7 @@ images:
     registry_paths:
       - docker.io/jujusolutions/charm-base
       - public.ecr.aws/juju/charm-base
+      - ghcr.io/juju/charm-base
     tags:
       - ubuntu-18.04
     platforms:


### PR DESCRIPTION
- Adds ghcr.io repository as a target for building.
- Adds juju 170 user and group into charm base for rootless juju.