### PR TITLE
Add super juju user and group called sjuju

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -4,13 +4,17 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-# Add the juju user for rootless agents.
-# 170 uid/gid is sourced from juju/juju
+# Add the juju and sjuju user for rootless agents.
+# 170 and 171 uid/gid is sourced from juju/juju
 RUN groupadd --gid 170 juju
 RUN useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju
+RUN groupadd --gid 171 sjuju
+RUN useradd --uid 171 --gid 171 --no-create-home --shell /usr/bin/bash sjuju
+RUN mkdir -p /etc/sudoers.d && echo "sjuju ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sjuju
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    sudo \
     python3-yaml \
     python3-pip \
     python3-distutils \


### PR DESCRIPTION
`sjuju` is a special user that is a sudoer that can used by charms in juju 3.4 that wish to run as a non-root user but still escalate to root when required.

JUJU-5129