### PR TITLE
feat: add noble support

### DIFF
--- a/Dockerfile-ubuntu-noble
+++ b/Dockerfile-ubuntu-noble
@@ -1,0 +1,28 @@
+# Copyright 2020 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+# Add the juju and sjuju user for rootless agents.
+# 170 and 171 uid/gid is sourced from juju/juju
+RUN groupadd --gid 170 juju
+RUN useradd --uid 170 --gid 170 --no-create-home --shell /usr/bin/bash juju
+RUN groupadd --gid 171 sjuju
+RUN useradd --uid 171 --gid 171 --no-create-home --shell /usr/bin/bash sjuju
+RUN mkdir -p /etc/sudoers.d && echo "sjuju ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sjuju
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    sudo \
+    python3-yaml \
+    python3-pip \
+    python3-setuptools \
+    # for debug-hooks.
+    tmux byobu \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /root/.cache
+
+ENTRYPOINT ["sh", "-c"]
+

--- a/images.yaml
+++ b/images.yaml
@@ -1,5 +1,27 @@
 images:
   # LTS
+  ubuntu-24-04:
+    dockerfile: Dockerfile-ubuntu-noble
+    context: ubuntu-context
+    registry_paths:
+      - docker.io/jujusolutions/charm-base
+      - public.ecr.aws/juju/charm-base
+      - ghcr.io/juju/charm-base
+    tags:
+      - ubuntu-24.04
+      - latest
+    platforms:
+      - linux/arm64
+      - linux/amd64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:24.04"
+    juju_test_channel: 3.5/stable
+    microk8s_test_channel: 1.30-strict/stable
+    series: noble
+
+  # LTS
   ubuntu-22-04:
     dockerfile: Dockerfile-ubuntu
     context: ubuntu-context
@@ -9,7 +31,6 @@ images:
       - ghcr.io/juju/charm-base
     tags:
       - ubuntu-22.04
-      - latest
     platforms:
       - linux/arm64
       - linux/amd64

--- a/test-charm/manifest.yaml
+++ b/test-charm/manifest.yaml
@@ -1,5 +1,9 @@
 bases:
   - name: ubuntu
+    channel: 24.04/stable
+    architectures:
+      - amd64
+  - name: ubuntu
     channel: 22.04/stable
     architectures:
       - amd64


### PR DESCRIPTION
This PR adds noble support.
Since Python 3.12, distutils has been [removed](https://docs.python.org/3.11/library/distutils.html).
Since Python 3.11, pip refuses to install to the system packages, requiring `--break-system-packages` to be passed. Instead here, we take the steps to break support with old charms on noble.