### PR TITLE
ci: fix actions on ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: build
 on:
   pull_request: {}
+  workflow_dispatch:
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest
@@ -43,6 +44,58 @@ jobs:
           sudo apt install -y make jq
           sudo snap install yq
 
+      - name: Install microk8s
+        run: |
+          microk8s_test_channel=$(yq ".images.[\"${{ matrix.image }}\"].microk8s_test_channel" < images.yaml)
+          sudo snap install microk8s --channel=${microk8s_test_channel} || sudo snap install microk8s --channel=${microk8s_test_channel} --classic
+          sudo microk8s.status --wait-ready
+          sudo microk8s.enable storage dns
+          sudo microk8s.status --wait-ready
+          microk8s_group=microk8s
+          if getent group snap_microk8s; then
+            microk8s_group=snap_microk8s
+          fi
+          sudo usermod -a -G "${microk8s_group}" "${USER}"
+
       - name: Make build image ${{ matrix.image }}
         run: |
           IMAGES=${{ matrix.image }} make build
+
+      - name: Install juju snap
+        run: |
+          juju_test_channel=$(yq ".images.[\"${{ matrix.image }}\"].juju_test_channel" < images.yaml)
+          sudo snap install juju --channel=${juju_test_channel} || sudo snap install juju --channel=${juju_test_channel} --classic
+          echo "installed juju $(juju version)"
+
+      - name: Copy built image to microk8s.ctr
+        run: |
+          IMAGES=${{ matrix.image }} make microk8s-image-update
+
+      - name: Bootstrap juju into microk8s
+        run: |
+          microk8s_group=microk8s
+          if getent group snap_microk8s; then
+            microk8s_group=snap_microk8s
+          fi
+          $(echo sudo su $USER -G ${microk8s_group} -g $(groups | sed "s/\s/ -G /g")) <<'EOF'
+            series=$(yq ".images.[\"${{ matrix.image }}\"].series" < images.yaml)
+            juju bootstrap microk8s
+            juju status -m controller
+            juju add-model test
+            juju deploy ./test-charm --series "${series}"
+
+            until juju status | grep -q "Image is all good."; do
+              sleep 1
+              juju status
+            done
+
+            image_tag="$(microk8s.kubectl -n test get pod ubuntu-test-0 -o json | jq -r '.status.containerStatuses | map(select(.name=="charm"))[0].image')"
+            expected_image_id="$(docker inspect ${image_tag} --format {{.ID}})"
+            got_image_id="$(microk8s.kubectl -n test get pod ubuntu-test-0 -o json | jq -r '.status.containerStatuses | map(select(.name=="charm"))[0].imageID')"
+            echo "image ${image_tag} built as ${expected_image_id}"
+            echo "image ${image_tag} used as ${got_image_id}"
+            if [ "${expected_image_id}" != "${got_image_id}" ]; then
+              echo "${got_image_id} does not match expected ${expected_image_id}"
+              exit 1
+            fi
+          EOF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
       - "master"
   schedule:
     - cron: "15 0 * * *"
+  workflow_dispatch:
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest
@@ -47,10 +48,6 @@ jobs:
           sudo apt install -y make jq
           sudo snap install yq
 
-      - name: Make build image ${{ matrix.image }}
-        run: |
-          IMAGES=${{ matrix.image }} make build
-
       - name: Install microk8s
         run: |
           microk8s_test_channel=$(yq ".images.[\"${{ matrix.image }}\"].microk8s_test_channel" < images.yaml)
@@ -63,6 +60,10 @@ jobs:
             microk8s_group=snap_microk8s
           fi
           sudo usermod -a -G "${microk8s_group}" $USER
+
+      - name: Make build image ${{ matrix.image }}
+        run: |
+          IMAGES=${{ matrix.image }} make build
 
       - name: Install juju snap
         run: |
@@ -80,7 +81,7 @@ jobs:
           if getent group snap_microk8s; then
             microk8s_group=snap_microk8s
           fi
-          sg "${microk8s_group}" <<'EOF'
+          $(echo sudo su $USER -G ${microk8s_group} -g $(groups | sed "s/\s/ -G /g")) <<'EOF'
             series=$(yq ".images.[\"${{ matrix.image }}\"].series" < images.yaml)
             juju bootstrap microk8s
             juju status -m controller


### PR DESCRIPTION
`sg` doesn't seem to work with the latest noble runners (it prompts for a password), so I've replaced it with an equivalent `sudo su` incantation.

Other changes here are adding the testing into the build job too, as the build job is just used for PR landing.