### PR TITLE
feat: add ubuntu 26.04 (resolute) as the new latest charm base image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Set up QEMU

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Set up QEMU
@@ -110,7 +111,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to ECR Public 
+      - name: Login to ECR Public
         uses: docker/login-action@v3
         with:
           registry: public.ecr.aws

--- a/images.yaml
+++ b/images.yaml
@@ -1,5 +1,27 @@
 images:
   # LTS
+  ubuntu-26-04:
+    dockerfile: Dockerfile-ubuntu-noble
+    context: ubuntu-context
+    registry_paths:
+      - docker.io/jujusolutions/charm-base
+      - public.ecr.aws/juju/charm-base
+      - ghcr.io/juju/charm-base
+    tags:
+      - ubuntu-26.04
+      - latest
+    platforms:
+      - linux/arm64
+      - linux/amd64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:26.04"
+    juju_test_channel: 3/stable
+    microk8s_test_channel: 1.34-strict/stable
+    series: resolute
+
+  # LTS
   ubuntu-24-04:
     dockerfile: Dockerfile-ubuntu-noble
     context: ubuntu-context
@@ -9,7 +31,6 @@ images:
       - ghcr.io/juju/charm-base
     tags:
       - ubuntu-24.04
-      - latest
     platforms:
       - linux/arm64
       - linux/amd64
@@ -17,7 +38,7 @@ images:
       - linux/s390x
     build_args:
       - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:24.04"
-    juju_test_channel: 3.5/stable
+    juju_test_channel: 3/stable
     microk8s_test_channel: 1.30-strict/stable
     series: noble
 
@@ -38,7 +59,7 @@ images:
       - linux/s390x
     build_args:
       - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:22.04"
-    juju_test_channel: 3.1/stable
+    juju_test_channel: 3/stable
     microk8s_test_channel: 1.25-strict/stable
     series: jammy
 

--- a/images.yaml
+++ b/images.yaml
@@ -39,7 +39,7 @@ images:
     build_args:
       - "BASE_IMAGE=public.ecr.aws/ubuntu/ubuntu:24.04"
     juju_test_channel: 3/stable
-    microk8s_test_channel: 1.30-strict/stable
+    microk8s_test_channel: 1.34-strict/stable
     series: noble
 
   # LTS

--- a/test-charm/manifest.yaml
+++ b/test-charm/manifest.yaml
@@ -1,5 +1,9 @@
 bases:
   - name: ubuntu
+    channel: 26.04/stable
+    architectures:
+      - amd64
+  - name: ubuntu
     channel: 24.04/stable
     architectures:
       - amd64


### PR DESCRIPTION
Moves the `latest` tag from ubuntu-24.04 to ubuntu-26.04 to track the new LTS release.

Reused `Dockerfile-ubuntu-noble` since it's still compatible with resolute.

Test it locally with:
```
IS_LOCAL=1 IMAGES=ubuntu-26-04 make build
```
